### PR TITLE
Allow custom anchors for the tooltip

### DIFF
--- a/lib/tooltip.js
+++ b/lib/tooltip.js
@@ -16,6 +16,7 @@ var Tooltip = React.createClass({
   mixins: [PureRenderMixin],
   propTypes: {
     align: React.PropTypes.string,
+    anchor: typeof Element === 'undefined' ? React.PropTypes.any : React.PropTypes.instanceOf(Element),
     children: React.PropTypes.any.isRequired
   },
   getDefaultProps() {
@@ -73,7 +74,7 @@ var Tooltip = React.createClass({
   _render() {
     ReactDOM.render(
       <TooltipInternal {...this.props}
-        anchor={this._container}
+        anchor={this.props.anchor || this._container}
         nubClassName={nubClasses[this.props.align]}
         className='round pad1 fill-white quiet shadow micro noevents contain' />,
       this._node);


### PR DESCRIPTION
The `anchor` prop can specify the position of the tooltip. The
value defaults to the parent node.
