### PR TITLE
Update React semver range for v15

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "react-pure-render": "^1.0.2"
   },
   "peerDependencies": {
-    "react": "0.14.x",
-    "react-dom": "0.14.x"
+    "react": "^0.14.0 || ^15.0.0",
+    "react-dom": "^0.14.0 || ^15.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.3.17",


### PR DESCRIPTION
I do not see any reason this module would fail with React v15. And I tried making a quick dummy app (via create-react-app) with it, and that worked. So I think this should be good to go.

@tmcw @scothis Any objections to merging and releasing?
